### PR TITLE
Hotfix: Pin openai package to version 0.28.1 to restore functionality

### DIFF
--- a/install.py
+++ b/install.py
@@ -4,4 +4,4 @@
 import launch
 
 if not launch.is_installed('openai'):
-    launch.run_pip('install openai', 'openai')
+    launch.run_pip('install openai==0.28.1', 'openai')


### PR DESCRIPTION
The openai package version 1.0.0 introduced breaking changes that caused AttributeError in sd-webui-chatgpt. This hotfix pins the package version to exactly 0.28.1 to quickly restore the system to a working state. Further changes will be needed to upgrade the code for compatibility with openai >=1.0.0.